### PR TITLE
payment

### DIFF
--- a/functions/charge.js
+++ b/functions/charge.js
@@ -1,0 +1,25 @@
+const stripe = require("stripe")(process.env.STRIPE_SECRET_KEY);
+
+exports.handler = async (event, context) => {
+  try {
+    const body = JSON.parse(event.body);
+
+    await stripe.charges.create({
+      amount: "9900", // "9900" --> $99.00
+      currency: "usd",
+      source: body.source,
+      description: "My great book"
+    });
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ success: true })
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: true })
+    };
+  }
+};

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -2,3 +2,13 @@
 import "typeface-montserrat";
 import "typeface-merriweather";
 import "firacode";
+
+import React from "react";
+import { Elements } from "@stripe/react-stripe-js";
+import { loadStripe } from "@stripe/stripe-js";
+
+const stripePromise = loadStripe(process.env.GATSBY_STRIPE_PUBLISHABLE_KEY);
+
+export const wrapRootElement = ({ element }) => {
+  return <Elements stripe={stripePromise}>{element}</Elements>;
+};

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -59,6 +59,5 @@ module.exports = {
     },
     `gatsby-plugin-offline`,
     `gatsby-plugin-react-helmet`,
-    "gatsby-plugin-no-javascript"
   ]
 };

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,0 +1,1 @@
+export { wrapRootElement } from "./gatsby-browser";

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   functions = "functions"
-  command = "yarn build"
+  command = "yarn build:site"
   publish = "public"
 
 [dev]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  functions = "functions"
+  command = "yarn build"
+  publish = "public"
+
+[dev]
+  autoLaunch = false

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "url": "https://github.com/SaraVieira/gatsby-starter-book/issues"
   },
   "dependencies": {
+    "@stripe/react-stripe-js": "^1.0.0-beta.5",
+    "@stripe/stripe-js": "^1.0.0-beta.5",
     "firacode": "^2.0.0",
     "framer-motion": "1.8.4",
     "gatsby": "2.19.12",
@@ -33,6 +35,7 @@
     "react-helmet": "5.2.1",
     "react-markdown": "4.3.1",
     "rehype-react": "4.0.1",
+    "stripe": "^8.14.0",
     "typeface-merriweather": "0.0.72",
     "typeface-montserrat": "0.0.75"
   },

--- a/src/pages/buy.js
+++ b/src/pages/buy.js
@@ -1,0 +1,43 @@
+import React from "react";
+import { CardElement, useStripe, useElements } from "@stripe/react-stripe-js";
+
+const BuyPage = () => {
+  const stripe = useStripe();
+  const elements = useElements();
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+
+    const { error, token } = await stripe.createToken(
+      elements.getElement(CardElement)
+    );
+
+    if (error) {
+      console.error(error);
+      return;
+    }
+
+    const response = await fetch("/.netlify/functions/charge", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ source: token.id })
+    }).then(response => response.json());
+
+    console.log(response);
+  };
+
+  return (
+    <div style={{ padding: 50 }}>
+      <form onSubmit={handleSubmit}>
+        <CardElement />
+        <button type="submit" style={{ marginTop: 20 }}>
+          Pay
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default BuyPage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1216,6 +1216,18 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
+"@stripe/react-stripe-js@^1.0.0-beta.5":
+  version "1.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@stripe/react-stripe-js/-/react-stripe-js-1.0.0-beta.5.tgz#5bc6d3c285d6b543f699b0e015525f2ff20cacec"
+  integrity sha512-CEZD4BbmcUzvNorVFpO5v0fL9C9eDRm0Jj9RJuONS0nhjfQwfBA+jNQ4WTZkE/LCAoLfED78AEa+FwUPFnb5cg==
+  dependencies:
+    prop-types "^15.7.2"
+
+"@stripe/stripe-js@^1.0.0-beta.5":
+  version "1.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-1.0.0-beta.5.tgz#460a46894bcca7d6bf9dd5564e0ed1c9a9c1c80e"
+  integrity sha512-UuGR04GbjB/0o1DV/S2Kj5nl6DKAXztP4rfS71NccLrqQzWq3bdwCBMwI2PouYrcb4rQE6mVWNCRByP0EHqHjg==
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
@@ -1303,7 +1315,7 @@
   resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.3.29.tgz#7f2ad7ec55f914482fc9b1ec4bb1ae6028d46066"
   integrity sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY=
 
-"@types/node@*":
+"@types/node@*", "@types/node@>=8.1.0":
   version "13.7.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.0.tgz#b417deda18cf8400f278733499ad5547ed1abec4"
   integrity sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==
@@ -10421,7 +10433,7 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.5.1:
+qs@^6.5.1, qs@^6.6.0:
   version "6.9.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.1.tgz#20082c65cb78223635ab1a9eaca8875a29bf8ec9"
   integrity sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==
@@ -12216,6 +12228,14 @@ strip-outer@^1.0.0:
   integrity sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==
   dependencies:
     escape-string-regexp "^1.0.2"
+
+stripe@^8.14.0:
+  version "8.14.0"
+  resolved "https://registry.yarnpkg.com/stripe/-/stripe-8.14.0.tgz#dd72c78d762fa1d92895a024a3bfb027184c6d5f"
+  integrity sha512-EbJFWVVM5xog/yxSimn4ZEUdBlqpixhchRp9d5xz69CLGFT4SQxdp1sB+A9iIk5mKipFMm31sEXx4cYsvRyjKA==
+  dependencies:
+    "@types/node" ">=8.1.0"
+    qs "^6.6.0"
 
 style-loader@^0.23.1:
   version "0.23.1"


### PR DESCRIPTION
#1 

Hey, so with Stripe new [React package](https://www.npmjs.com/package/@stripe/react-stripe-js), it's a much better experience to add Stripe to a React project now.

- To run this PR, you would need to add 2 environment variables to your project on Netlify `STRIPE_SECRET_KEY` and `GATSBY_STRIPE_PUBLISHABLE_KEY`.

- After pulling this PR down, you can run `netlify dev` and visit `localhost:8888/buy` to try it out.

Let me know if you have any questions.

After this, we would need to think about some sort of authentication to limit access to the content. I think `Netlify Identity` and `Netlify Redirects` would be a good fit for this, although it will add a layer of friction to the checkout process as people would need to create an account before buying.