### PR TITLE
Add yarn install to how to use steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,15 @@ git clone git@github.com:SaraVieira/starter-book.git my-book && cd my-book
 
 2. Edit your book in the `book.md`
 3. Set you book properties in `bookInfo.js`
-4. Run `yarn build`
+4. Run `yarn install`
+5. Run `yarn build`
 
-   4.1. You can also run `yarn build:site` to build just the preview site
+   5.1. You can also run `yarn build:site` to build just the preview site
 
-   4.2. Or run `yarn build:book` for the PDF and Epub files
+   5.2. Or run `yarn build:book` for the PDF and Epub files
 
-5. To get the .mobi file download the [Kindle Previewer](https://kdp.amazon.com/en_US/help/topic/G202131170) and drag your .epub file and it creates a kindle compatible file.
-6. Profit??
+6. To get the .mobi file download the [Kindle Previewer](https://kdp.amazon.com/en_US/help/topic/G202131170) and drag your .epub file and it creates a kindle compatible file.
+7. Profit??
 
 ## FAQ
 


### PR DESCRIPTION
I'm not familiar with `yarn` and the commands it makes available so not having the project dependencies installed caught me out initially. Then I ran `npm install` and all hell broke loose as that doesn't pay any attention to `yarn.lock`, meaning the versions of the dependencies which were installed were different to those specified in the yarn lockfile and had various compatibility issues. `yarn install` got everything working like magic ✨