### PR TITLE
Fix Link to 'Edit on github' leads to 404 #14

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         repo: "https://github.com/SaraVieira/starter-book",
         plugins: [
           window.EditOnGithubPlugin.create(
-            "https://github.com/SaraVieira/starter-book/tree/docs"
+            "https://github.com/SaraVieira/starter-book/tree/docs/"
           ),
         ],
       };


### PR DESCRIPTION
Hey again, 
It was a missing slash.

